### PR TITLE
Prevent exceptions when no Library is Loaded

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -3640,11 +3640,11 @@ class QtDriver(QObject):
 		file_menu.addAction(open_library_action)
 
 		save_library_action = QAction('&Save Library', menu_bar)
-		save_library_action.triggered.connect(lambda: self.save_library())
+		save_library_action.triggered.connect(lambda: self.callback_library_needed_check(self.save_library))
 		file_menu.addAction(save_library_action)
 	
 		save_library_backup_action = QAction('Save Library &Backup', menu_bar)
-		save_library_backup_action.triggered.connect(lambda: self.backup_library())
+		save_library_backup_action.triggered.connect(lambda: self.callback_library_needed_check(self.backup_library))
 		file_menu.addAction(save_library_backup_action)
 
 		file_menu.addSeparator()
@@ -3652,7 +3652,7 @@ class QtDriver(QObject):
 		# refresh_lib_action = QAction('&Refresh Directories', self.main_window)
 		# refresh_lib_action.triggered.connect(lambda: self.lib.refresh_dir())
 		add_new_files_action = QAction('&Refresh Directories', menu_bar)
-		add_new_files_action.triggered.connect(lambda: self.add_new_files_callback())
+		add_new_files_action.triggered.connect(lambda: self.callback_library_needed_check(self.add_new_files_callback))
 		# file_menu.addAction(refresh_lib_action)
 		file_menu.addAction(add_new_files_action)
 
@@ -3780,6 +3780,13 @@ class QtDriver(QObject):
 
 		self.shutdown()
 
+
+	def callback_library_needed_check(self,func):
+		#Check if loaded library has valid path before executing the button function
+		if self.lib.library_dir:
+			func()
+
+
 	def handleSIGTERM(self):
 		self.shutdown()
 		
@@ -3791,8 +3798,6 @@ class QtDriver(QObject):
 	
 	
 	def save_library(self):
- 		if not self.lib.library_dir:
-			return
 		logging.info(f'Saving Library...')
 		self.main_window.statusbar.showMessage(f'Saving Library...')
 		start_time = time.time()
@@ -3801,8 +3806,6 @@ class QtDriver(QObject):
 		self.main_window.statusbar.showMessage(f'Library Saved! ({format_timespan(end_time - start_time)})')
 
 	def backup_library(self):
- 		if not self.lib.library_dir:
-			return
 		logging.info(f'Backing Up Library...')
 		self.main_window.statusbar.showMessage(f'Saving Library...')
 		start_time = time.time()
@@ -3811,8 +3814,6 @@ class QtDriver(QObject):
 		self.main_window.statusbar.showMessage(f'Library Backup Saved at: "{os.path.normpath(os.path.normpath(f"{self.lib.library_dir}/{TS_FOLDER_NAME}/{BACKUP_FOLDER_NAME}/{fn}"))}" ({format_timespan(end_time - start_time)})')
 	
 	def add_tag_action_callback(self):
- 		if not self.lib.library_dir:
-			return
 		self.modal = PanelModal(BuildTagPanel(self.lib), 
 								'New Tag', 
 								'Add Tag',

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -3791,6 +3791,8 @@ class QtDriver(QObject):
 	
 	
 	def save_library(self):
+ 		if not self.lib.library_dir:
+			return
 		logging.info(f'Saving Library...')
 		self.main_window.statusbar.showMessage(f'Saving Library...')
 		start_time = time.time()
@@ -3799,6 +3801,8 @@ class QtDriver(QObject):
 		self.main_window.statusbar.showMessage(f'Library Saved! ({format_timespan(end_time - start_time)})')
 
 	def backup_library(self):
+ 		if not self.lib.library_dir:
+			return
 		logging.info(f'Backing Up Library...')
 		self.main_window.statusbar.showMessage(f'Saving Library...')
 		start_time = time.time()
@@ -3807,6 +3811,8 @@ class QtDriver(QObject):
 		self.main_window.statusbar.showMessage(f'Library Backup Saved at: "{os.path.normpath(os.path.normpath(f"{self.lib.library_dir}/{TS_FOLDER_NAME}/{BACKUP_FOLDER_NAME}/{fn}"))}" ({format_timespan(end_time - start_time)})')
 	
 	def add_tag_action_callback(self):
+ 		if not self.lib.library_dir:
+			return
 		self.modal = PanelModal(BuildTagPanel(self.lib), 
 								'New Tag', 
 								'Add Tag',


### PR DESCRIPTION
Before this Refresh Directorys/Save Library/Save Library Backup (in File Menu) would throw an exception if no library was loaded this prevents that.