### PR TITLE
Allow network path libraries

### DIFF
--- a/tagstudio/src/core/library.py
+++ b/tagstudio/src/core/library.py
@@ -540,7 +540,7 @@ class Library:
 		2: File creation error
 		"""
 		
-		path = os.path.normpath(path).strip('\\')
+		path = os.path.normpath(path).rstrip('\\')
 
 		if ts_core.TS_FOLDER_NAME in path:
 			return 1


### PR DESCRIPTION
Swap normalized path strip from using strip to using rstrip to avoid stripping leading slashes

See #29 for additional details