### PR TITLE
python 3.12 support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,8 @@ humanfriendly==10.0
 opencv_python>=4.8.0.74,<=4.9.0.80
 Pillow==10.3.0
 pillow_avif_plugin>=1.3.1,<=1.4.3
-PySide6>=6.5.1.1,<=6.7
-PySide6_Addons>=6.5.1.1,<=6.7
-PySide6_Essentials>=6.5.1.1,<=6.7
+PySide6>=6.5.1.1,<=6.6.3.1
+PySide6_Addons>=6.5.1.1,<=6.6.3.1
+PySide6_Essentials>=6.5.1.1,<=6.6.3.1
 typing_extensions>=3.10.0.0,<=4.11.0
 ujson>=5.8.0,<=5.9.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 humanfriendly==10.0
-opencv_python==4.8.0.74
+opencv_python>=4.8.0.74,<=4.9.0.80
 Pillow==10.3.0
-pillow_avif_plugin==1.3.1
-PySide6==6.5.1.1
-PySide6_Addons==6.5.1.1
-PySide6_Essentials==6.5.1.1
-typing_extensions==3.10.0.0
-ujson==5.8.0
+pillow_avif_plugin>=1.3.1,<=1.4.3
+PySide6>=6.5.1.1,<=6.7
+PySide6_Addons>=6.5.1.1,<=6.7
+PySide6_Essentials>=6.5.1.1,<=6.7
+typing_extensions>=3.10.0.0,<=4.11.0
+ujson>=5.8.0,<=5.9.0


### PR DESCRIPTION
Enables the program to be run with python3.12 aswell as supporting older version.
Pyside6 is purposly limited to 3.6.3.1 because 3.7 seems to have a bug that breaks the programm(should be [this ](https://bugreports.qt.io/browse/PYSIDE-2675) )that will hopefully be fixed in 3.7.1. 
All other versions are corectly selected by pip
(Tested with 3.10 and 3.12)
it should also work with 3.9.6 because all original versions of the packages are in the range described in this file.