### PR TITLE
Add NixOS Dev Environment Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,10 @@ With the virtual environment loaded, run the python file at "tagstudio/tagstudio
 
 Run the "TagStudio.sh" script, and the program should launch! (Make sure that the script is marked as executable). Note that launching from the script from outside of a terminal will not launch a terminal window with any debug or crash information. If you wish to see this information, just launch the shell script directly from your terminal with `sh TagStudio.sh`.
 
+##### NixOS
+
+Use the provided `flake.nix` file to create and enter a working environment by running `nix develop`. Then, run the above `TagStudio.sh` script.
+
 ## Usage
 
 ### Creating/Opening a Library

--- a/TagStudio.sh
+++ b/TagStudio.sh
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /usr/bin/env bash
 python3 -m venv .venv
 source .venv/bin/activate
 pip install -r requirements.txt

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1688072080,
-        "narHash": "sha256-mPsxREerkmDU2m7zi8j19ooc1F9wKPWBJ77S7swXMmI=",
+        "lastModified": 1712473363,
+        "narHash": "sha256-TIScFAVdI2yuybMxxNjC4YZ/j++c64wwuKbpnZnGiyU=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "5a8650469a9f8a1958ff9373bd27fb8e54c4365d",
+        "rev": "e89cf1c932006531f454de7d652163a9a5c86668",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1688072080,
+        "narHash": "sha256-mPsxREerkmDU2m7zi8j19ooc1F9wKPWBJ77S7swXMmI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5a8650469a9f8a1958ff9373bd27fb8e54c4365d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -18,6 +18,8 @@
         pkgs.freetype
         pkgs.dbus
         pkgs.qt6.qtwayland
+        pkgs.qt6.full
+        pkgs.qt6.qtbase
         pkgs.zstd
       ];
       buildInputs = with pkgs; [
@@ -28,13 +30,12 @@
         qt6.full
         qt6.qtwayland
         qtcreator
-        python310Packages.pip
-        python310Full
-        python310Packages.virtualenv # run virtualenv .
-        # python3Packages.pyqt5 # avoid installing via pip
-        python310Packages.pyusb # fixes the pyusb 'No backend available' when installed directly via pip
+        python312Packages.pip
+        python312Full
+        python312Packages.virtualenv # run virtualenv .
+        python312Packages.pyusb # fixes the pyusb 'No backend available' when installed directly via pip
 
-        gcc.cc.libgcc
+        libgcc
         makeWrapper
         bashInteractive
         glib
@@ -46,7 +47,6 @@
         libGL
         libGLU
         fontconfig
-        # wrapQtAppsHook
         xorg.libxcb
 
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,70 @@
+{
+  inputs.nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+
+  outputs = { self, nixpkgs, }:
+  let
+    pkgs = nixpkgs.legacyPackages.x86_64-linux;
+  in {
+    devShells.x86_64-linux.default = pkgs.mkShell {
+      LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+        pkgs.gcc-unwrapped
+        pkgs.zlib
+        pkgs.libglvnd
+        pkgs.glib
+        pkgs.stdenv.cc.cc
+        pkgs.fontconfig
+        pkgs.libxkbcommon
+        pkgs.xorg.libxcb
+        pkgs.freetype
+        pkgs.dbus
+        pkgs.qt6.qtwayland
+        pkgs.zstd
+      ];
+      buildInputs = with pkgs; [
+        cmake
+        gdb
+        zstd
+        qt6.qtbase
+        qt6.full
+        qt6.qtwayland
+        qtcreator
+        python310Packages.pip
+        python310Full
+        python310Packages.virtualenv # run virtualenv .
+        # python3Packages.pyqt5 # avoid installing via pip
+        python310Packages.pyusb # fixes the pyusb 'No backend available' when installed directly via pip
+
+        gcc.cc.libgcc
+        makeWrapper
+        bashInteractive
+        glib
+        libxkbcommon
+        freetype
+        binutils
+        dbus
+        coreutils
+        libGL
+        libGLU
+        fontconfig
+        # wrapQtAppsHook
+        xorg.libxcb
+
+
+        # this is for the shellhook portion
+        qt6.wrapQtAppsHook
+        makeWrapper
+        bashInteractive
+      ];
+      # set the environment variables that Qt apps expect
+      shellHook = ''
+        export QT_QPA_PLATFORM=wayland
+        export LIBRARY_PATH=/usr/lib:/usr/lib64:$LIBRARY_PATH
+        # export LD_LIBRARY_PATH=${pkgs.stdenv.cc.cc.lib}/lib/:/run/opengl-driver/lib/
+        export QT_PLUGIN_PATH=${pkgs.qt6.qtbase}/${pkgs.qt6.qtbase.qtPluginPrefix}
+        bashdir=$(mktemp -d)
+        makeWrapper "$(type -p bash)" "$bashdir/bash" "''${qtWrapperArgs[@]}"
+        exec "$bashdir/bash"
+      '';
+    };
+  };
+}


### PR DESCRIPTION
- Add necessary flake files to allow for a NixOS development environment.
- Update the `TagStudio.sh` bash script to use `/usr/bin/env bash` instead of `/bin/bash` to allow NixOS to run it.
- Update `README.md` with documentation on running the Nix environment.

Can now run `nix develop` on Nix, and then can run the TagStudio script and the application will launch as expected. 

Let me know if anything needs fixing!

_Note to any Nix people: The way I setup the environment is probably needlessly obtuse, but I got the app launching. This can probably be a lot simpler if someone has a smarter way of doing it._