### PR TITLE
 Allow files to be opened in their respective programs in the background for Windows, MacOS, and Linux

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -41,6 +41,8 @@ import src.qt.resources_rc
 # from typing_extensions import deprecated
 from humanfriendly import format_timespan
 # from src.qt.qtacrylic.qtacrylic import WindowEffect
+import shutil
+import subprocess
 
 # SIGQUIT is not defined on Windows
 if sys.platform == "win32":
@@ -56,13 +58,21 @@ INFO = f'[INFO]'
 logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
-def open_file(path):
-	try:
-		os.startfile(path)
-	except FileNotFoundError:
-		logging.info('File Not Found! (Imagine this as a popup)')
-	except:
-		traceback.print_exc()
+def open_file(path: str):
+	if sys.platform == "win32":
+		command_name = "start"
+	elif sys.platform == "darwin":
+		command_name = "open"
+	else:
+		command_name = "xdg-open"
+	command = shutil.which(command_name)
+	if command is not None:
+		try:
+			subprocess.Popen([command, path], close_fds=True)
+		except:
+			traceback.print_exc()
+	else:
+		logging.info(f"Could not find {command_name} on system PATH")
 
 
 class NavigationState():

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -59,20 +59,21 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 
 
 def open_file(path: str):
-	if sys.platform == "win32":
-		command_name = "start"
-	elif sys.platform == "darwin":
-		command_name = "open"
-	else:
-		command_name = "xdg-open"
-	command = shutil.which(command_name)
-	if command is not None:
-		try:
-			subprocess.Popen([command, path], close_fds=True)
-		except:
-			traceback.print_exc()
-	else:
-		logging.info(f"Could not find {command_name} on system PATH")
+	try:
+		if sys.platform == "win32":
+			subprocess.Popen(["start", path], shell=True, close_fds=True)
+		else:
+			if sys.platform == "darwin":
+				command_name = "open"
+			else:
+				command_name = "xdg-open"
+			command = shutil.which(command_name)
+			if command is not None:
+				subprocess.Popen([command, path], close_fds=True)
+			else:
+				logging.info(f"Could not find {command_name} on system PATH")
+	except:
+		traceback.print_exc()
 
 
 class NavigationState():

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -61,7 +61,7 @@ logging.basicConfig(format="%(message)s", level=logging.INFO)
 def open_file(path: str):
 	try:
 		if sys.platform == "win32":
-			subprocess.Popen(["start", path], shell=True, close_fds=True)
+			subprocess.Popen(["start", path], shell=True, close_fds=True, creationflags=subprocess.DETACHED_PROCESS)
 		else:
 			if sys.platform == "darwin":
 				command_name = "open"


### PR DESCRIPTION
Uses subprocess.Popen() along with start/open/xdg-open to open a file in its respective program. This process will last even after the TagStudio process exits.

Note: **this has only been tested on Linux!**

---
Recreation of #42.