### PR TITLE
QOL Open last opened library

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -3577,6 +3577,7 @@ class QtDriver(QObject):
 		self.SIGTERM.connect(self.handleSIGTERM)
 
 		self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, 'TagStudio')
+		self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, 'tagstudio', 'TagStudio')
 
 
 		max_threads = os.cpu_count()
@@ -3830,6 +3831,7 @@ class QtDriver(QObject):
 		if self.lib.library_dir:
 			self.save_library()
 			self.settings.setValue("last_library", self.lib.library_dir)
+			self.settings.sync()
 		QApplication.quit()
 	
 	

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -3576,7 +3576,6 @@ class QtDriver(QObject):
 
 		self.SIGTERM.connect(self.handleSIGTERM)
 
-		self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, 'TagStudio')
 		self.settings = QSettings(QSettings.IniFormat, QSettings.UserScope, 'tagstudio', 'TagStudio')
 
 


### PR DESCRIPTION
Adds a QSettings object to the QtDriver, saves the last library on exit and auto reloads that library on next launch

To keep from polluting system/user directories and/or the windows registry an `.ini` format is used with the storage path overwritten to the cwd at time of launch.