### PR TITLE
Windows: fix files w/ spaces opening cmd rather than associated program

### DIFF
--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -69,7 +69,8 @@ def open_file(path: str):
 	try:
 		if sys.platform == "win32":
 			# Windows needs special attention to handle spaces in the file
-			subprocess.Popen(["start", f'"{path.replace('"', '\"')}"'], shell=True, close_fds=True, creationflags=subprocess.DETACHED_PROCESS)
+			# first parameter is for title, NOT filepath
+			subprocess.Popen(["start", "", os.path.normpath(path)], shell=True, close_fds=True, creationflags=subprocess.DETACHED_PROCESS)
 		else:
 			if sys.platform == "darwin":
 				command_name = "open"

--- a/tagstudio/src/qt/ts_qt.py
+++ b/tagstudio/src/qt/ts_qt.py
@@ -68,7 +68,8 @@ QSettings.setPath(QSettings.IniFormat, QSettings.UserScope, os.getcwd())
 def open_file(path: str):
 	try:
 		if sys.platform == "win32":
-			subprocess.Popen(["start", path], shell=True, close_fds=True, creationflags=subprocess.DETACHED_PROCESS)
+			# Windows needs special attention to handle spaces in the file
+			subprocess.Popen(["start", f'"{path.replace('"', '\"')}"'], shell=True, close_fds=True, creationflags=subprocess.DETACHED_PROCESS)
 		else:
 			if sys.platform == "darwin":
 				command_name = "open"


### PR DESCRIPTION
Tite. Path needs to be wrapped in quotes, and any inner quotes are escaped.

Note: untested as I am on Linux.